### PR TITLE
feature/ add roles & corresponding units tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+*.graphql
+*.md
+*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Support for `RoleGranted` and `RoleRevoked` event handling in the voucherHub module:
+- Support for `RoleGranted` and `RoleRevoked` event handling in the voucherHub module (#19):
   - Recognized roles are now mapped to specific names:
     - UPGRADER_ROLE (`0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3`)
     - MANAGER_ROLE (`0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## vNEXT
 
+### Added
+
+- Support for `RoleGranted` and `RoleRevoked` event handling in the voucherHub module:
+  - Recognized roles are now mapped to specific names:
+    - UPGRADER_ROLE (`0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3`)
+    - MANAGER_ROLE (`0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08`)
+    - MINTER_ROLE (`0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6`)
+  - Unrecognized roles are labeled as UNKNOWN_ROLE.
+
+### Changed
+
 - [BREAKING] Update: Transition to RLC as the Unit in Subgraph Fields. The unit for several fields in the subgraph will be updated from nRLC to RLC (#11). The impacted fields include:
   - appPrice
   - datasetPrice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support for `RoleGranted` and `RoleRevoked` event handling in the voucherHub module (#19):
   - Recognized roles are now mapped to specific names:
+    - DEFAULT_ADMIN_ROLE (`0x00`)
     - UPGRADER_ROLE (`0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3`)
     - MANAGER_ROLE (`0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08`)
     - MINTER_ROLE (`0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6`)

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,6 +1,13 @@
 type Account @entity {
   id: ID!
   voucher: Voucher @derivedFrom(field: "owner")
+  role: Role 
+}
+
+type Role @entity {
+  id: ID!
+  name: String
+  accounts: [Account!]! @derivedFrom(field: "role")
 }
 
 type VoucherType @entity {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,20 +66,13 @@ export function nRLCToRLC(value: BigInt): BigInt {
 }
 
 export function getRoleName(roleId: string): string {
-    // Role ID mappings (precomputed hashes)
-    const ROLE_NAMES: Map<string, string> = new Map<string, string>();
-    ROLE_NAMES.set(
-        '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3',
-        'UPGRADER_ROLE',
-    );
-    ROLE_NAMES.set(
-        '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08',
-        'MANAGER_ROLE',
-    );
-    ROLE_NAMES.set(
-        '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6',
-        'MINTER_ROLE',
-    );
-
-    return ROLE_NAMES.has(roleId) ? ROLE_NAMES.get(roleId)! : 'UNKNOWN_ROLE';
+    if (roleId == '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3') {
+        return 'UPGRADER_ROLE';
+    } else if (roleId == '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08') {
+        return 'MANAGER_ROLE';
+    } else if (roleId == '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6') {
+        return 'MINTER_ROLE';
+    } else {
+        return 'UNKNOWN_ROLE';
+    }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
-import { Account, App, Dataset, Workerpool } from '../generated/schema';
+import { Account, App, Dataset, Role, Workerpool } from '../generated/schema';
 import { App as AppContract } from '../generated/templates/Voucher/App';
 import { Dataset as DatasetContract } from '../generated/templates/Voucher/Dataset';
 import { Workerpool as WorkerpoolContract } from '../generated/templates/Voucher/Workerpool';
@@ -11,6 +11,16 @@ export function loadOrCreateAccount(id: string): Account {
         account.save();
     }
     return account;
+}
+
+export function loadOrCreateRole(id: string): Role {
+    let role = Role.load(id);
+    if (!role) {
+        role = new Role(id);
+        role.name = getRoleName(id);
+        role.save();
+    }
+    return role;
 }
 
 export function loadOrCreateApp(address: Address): App {
@@ -53,4 +63,23 @@ export function getEventId(event: ethereum.Event): string {
 export function nRLCToRLC(value: BigInt): BigInt {
     let divisor = BigInt.fromI32(1_000_000_000);
     return value.div(divisor);
+}
+
+export function getRoleName(roleId: string): string {
+    // Role ID mappings (precomputed hashes)
+    const ROLE_NAMES: Map<string, string> = new Map<string, string>();
+    ROLE_NAMES.set(
+        '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3',
+        'UPGRADER_ROLE',
+    );
+    ROLE_NAMES.set(
+        '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08',
+        'MANAGER_ROLE',
+    );
+    ROLE_NAMES.set(
+        '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6',
+        'MINTER_ROLE',
+    );
+
+    return ROLE_NAMES.has(roleId) ? ROLE_NAMES.get(roleId)! : 'UNKNOWN_ROLE';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -66,7 +66,11 @@ export function nRLCToRLC(value: BigInt): BigInt {
 }
 
 export function getRoleName(roleId: string): string {
-    if (roleId == '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3') {
+    // DEFAULT_ADMIN_ROLE make reference to OpenZeppelin's
+    // AccessControl.sol (https://github.com/OpenZeppelin/openzeppelin-contracts/blob/bf69b601468a6a4f78b8c85f9a31c3690d613a71/contracts/access/AccessControl.sol#L57)
+    if (roleId == '0x00') {
+        return 'DEFAULT_ADMIN_ROLE';
+    } else if (roleId == '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3') {
         return 'UPGRADER_ROLE';
     } else if (roleId == '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08') {
         return 'MANAGER_ROLE';

--- a/src/voucherHub.ts
+++ b/src/voucherHub.ts
@@ -4,6 +4,8 @@ import { PoCo } from '../generated/VoucherHub/PoCo';
 import {
     EligibleAssetAdded,
     EligibleAssetRemoved,
+    RoleGranted,
+    RoleRevoked,
     VoucherCreated,
     VoucherDebited,
     VoucherDrained,
@@ -22,6 +24,7 @@ import {
     loadOrCreateAccount,
     loadOrCreateApp,
     loadOrCreateDataset,
+    loadOrCreateRole,
     loadOrCreateWorkerpool,
     nRLCToRLC,
 } from './utils';
@@ -214,4 +217,18 @@ export function handleVoucherTypeDurationUpdated(event: VoucherTypeDurationUpdat
         voucherType.duration = duration;
         voucherType.save();
     }
+}
+
+export function handleRoleGranted(event: RoleGranted): void {
+    let account = loadOrCreateAccount(event.params.account.toHex());
+    let role = loadOrCreateRole(event.params.role.toHex());
+    account.role = role.id;
+    account.save();
+}
+
+export function handleRoleRevoked(event: RoleRevoked): void {
+    loadOrCreateRole(event.params.role.toHex());
+    let account = loadOrCreateAccount(event.params.account.toHex());
+    account.role = null; // Clear the role when revoked
+    account.save();
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -25,6 +25,7 @@ dataSources:
         - App
         - Dataset
         - Workerpool
+        - Role
       abis:
         - name: VoucherHub
           file: node_modules/@iexec/voucher-contracts/artifacts/contracts/VoucherHub.sol/VoucherHub.json
@@ -63,6 +64,10 @@ dataSources:
           handler: handleVoucherTypeDescriptionUpdated
         - event: VoucherTypeDurationUpdated(indexed uint256,uint256)
           handler: handleVoucherTypeDurationUpdated
+        - event: RoleGranted(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleGranted
+        - event: RoleRevoked(indexed bytes32,indexed address,indexed address)
+          handler: handleRoleRevoked
       file: ./src/voucherHub.ts
 
 templates:

--- a/tests/unit/utils/utils.ts
+++ b/tests/unit/utils/utils.ts
@@ -1,8 +1,10 @@
-import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { Address, BigInt, Bytes, ethereum } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly/index';
 import {
     EligibleAssetAdded,
     EligibleAssetRemoved,
+    RoleGranted,
+    RoleRevoked,
     VoucherCreated,
 } from '../../../generated/VoucherHub/VoucherHub';
 import { App, Dataset, Workerpool } from '../../../generated/schema';
@@ -75,6 +77,44 @@ export function createEligibleAssetAddedEvent(id: BigInt, asset: Address): Eligi
 
     event.parameters.push(new ethereum.EventParam('id', ethereum.Value.fromUnsignedBigInt(id)));
     event.parameters.push(new ethereum.EventParam('asset', ethereum.Value.fromAddress(asset)));
+
+    return event;
+}
+
+export function createRoleGrantedEvent(account: Address, role: Bytes): RoleGranted {
+    let mockEvent = newMockEvent();
+    let event = new RoleGranted(
+        mockEvent.address,
+        mockEvent.logIndex,
+        mockEvent.transactionLogIndex,
+        mockEvent.logType,
+        mockEvent.block,
+        mockEvent.transaction,
+        new Array(),
+        mockEvent.receipt,
+    );
+
+    event.parameters.push(new ethereum.EventParam('role', ethereum.Value.fromBytes(role)));
+    event.parameters.push(new ethereum.EventParam('account', ethereum.Value.fromAddress(account)));
+
+    return event;
+}
+
+export function createRoleRevokedEvent(account: Address, role: Bytes): RoleRevoked {
+    let mockEvent = newMockEvent();
+    let event = new RoleRevoked(
+        mockEvent.address,
+        mockEvent.logIndex,
+        mockEvent.transactionLogIndex,
+        mockEvent.logType,
+        mockEvent.block,
+        mockEvent.transaction,
+        new Array(),
+        mockEvent.receipt,
+    );
+
+    event.parameters.push(new ethereum.EventParam('role', ethereum.Value.fromBytes(role)));
+    event.parameters.push(new ethereum.EventParam('account', ethereum.Value.fromAddress(account)));
 
     return event;
 }

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -7,6 +7,7 @@ import { createRoleGrantedEvent, createRoleRevokedEvent } from '../utils/utils';
 
 // Constants for testing
 const ACCOUNT_ID = '0x1234567890abcdef1234567890abcdef12345678';
+const DEFAULT_ADMIN_ROLE_ID = '0x00';
 const UPGRADER_ROLE_ID = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
 const MANAGER_ROLE_ID = '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08';
 const MINTER_ROLE_ID = '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6';
@@ -27,6 +28,22 @@ function setupInitialAccount(accountId: string, roleId: string | null): void {
 describe('Role Handlers', () => {
     beforeEach(() => {
         clearStore();
+    });
+
+    test('Should assign DEFAULT_ADMIN_ROLE to an account on RoleGranted event', () => {
+        // --- GIVEN
+        const event = createRoleGrantedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(DEFAULT_ADMIN_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleGranted(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', DEFAULT_ADMIN_ROLE_ID);
+        assert.fieldEquals('Role', DEFAULT_ADMIN_ROLE_ID, 'name', 'DEFAULT_ADMIN_ROLE');
     });
 
     test('Should assign UPGRADER_ROLE_ID to an account on RoleGranted event', () => {
@@ -75,6 +92,24 @@ describe('Role Handlers', () => {
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
         assert.fieldEquals('Account', ACCOUNT_ID, 'role', MINTER_ROLE_ID);
         assert.fieldEquals('Role', MINTER_ROLE_ID, 'name', 'MINTER_ROLE');
+    });
+
+    test('Should revoke DEFAULT_ADMIN_ROLE from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, DEFAULT_ADMIN_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(DEFAULT_ADMIN_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', DEFAULT_ADMIN_ROLE_ID, 'name', 'DEFAULT_ADMIN_ROLE');
     });
 
     test('Should revoke UPGRADER_ROLE from an account on RoleRevoked event', () => {

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -7,7 +7,7 @@ import { createRoleGrantedEvent, createRoleRevokedEvent } from '../utils/utils';
 
 // Constants for testing
 const ACCOUNT_ID = '0x1234567890abcdef1234567890abcdef12345678';
-const VALID_ROLE_ID = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
+const UPGRADER_ROLE = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
 const MANAGER_ROLE_ID = '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08';
 const MINTER_ROLE_ID = '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6';
 const UNKNOWN_ROLE_ID = '0x544b2cd71ba72d14e3ad1fab938f5145ba5fc248560466e1d7cc20c78080e0fb';
@@ -33,7 +33,7 @@ describe('Role Handlers', () => {
         // --- GIVEN
         const event = createRoleGrantedEvent(
             Address.fromString(ACCOUNT_ID),
-            Bytes.fromHexString(VALID_ROLE_ID),
+            Bytes.fromHexString(UPGRADER_ROLE),
         );
 
         // WHEN
@@ -41,8 +41,8 @@ describe('Role Handlers', () => {
 
         // THEN
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
-        assert.fieldEquals('Account', ACCOUNT_ID, 'role', VALID_ROLE_ID);
-        assert.fieldEquals('Role', VALID_ROLE_ID, 'name', 'UPGRADER_ROLE');
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', UPGRADER_ROLE);
+        assert.fieldEquals('Role', UPGRADER_ROLE, 'name', 'UPGRADER_ROLE');
     });
 
     test('Should assign MANAGER_ROLE to an account on RoleGranted event', () => {

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -1,0 +1,97 @@
+import { Address, Bytes } from '@graphprotocol/graph-ts';
+import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
+import { Account, Role } from '../../../generated/schema';
+import { getRoleName } from '../../../src/utils';
+import { handleRoleGranted, handleRoleRevoked } from '../../../src/voucherHub';
+import { createRoleGrantedEvent, createRoleRevokedEvent } from '../utils/utils';
+
+// Constants for testing
+const ACCOUNT_ID = '0x1234567890abcdef1234567890abcdef12345678';
+const VALID_ROLE_ID = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
+const UNKNOWN_ROLE_ID = '0x544b2cd71ba72d14e3ad1fab938f5145ba5fc248560466e1d7cc20c78080e0fb';
+
+function setupInitialAccount(accountId: string, roleId: string | null): void {
+    let account = new Account(accountId);
+    account.role = roleId;
+    account.save();
+
+    if (roleId) {
+        let role = new Role(roleId);
+        role.name = getRoleName(roleId);
+        role.save();
+    }
+}
+
+describe('Role Handlers', () => {
+    beforeEach(() => {
+        clearStore();
+    });
+
+    test('Should assign a recognized role to an account on RoleGranted event', () => {
+        // --- GIVEN
+        const event = createRoleGrantedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(VALID_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleGranted(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', VALID_ROLE_ID);
+        assert.fieldEquals('Role', VALID_ROLE_ID, 'name', 'UPGRADER_ROLE');
+    });
+
+    test('Should assign an unknown role to an account on RoleGranted event', () => {
+        // --- GIVEN
+        const event = createRoleGrantedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(UNKNOWN_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleGranted(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', UNKNOWN_ROLE_ID);
+        assert.fieldEquals('Role', UNKNOWN_ROLE_ID, 'name', 'UNKNOWN_ROLE');
+    });
+
+    test('Should revoke a recognized role from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, VALID_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(VALID_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', VALID_ROLE_ID, 'name', 'UPGRADER_ROLE');
+    });
+
+    test('Should revoke an unknown role from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, UNKNOWN_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(UNKNOWN_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', UNKNOWN_ROLE_ID, 'name', 'UNKNOWN_ROLE');
+    });
+});

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -46,7 +46,7 @@ describe('Role Handlers', () => {
         assert.fieldEquals('Role', DEFAULT_ADMIN_ROLE_ID, 'name', 'DEFAULT_ADMIN_ROLE');
     });
 
-    test('Should assign UPGRADER_ROLE_ID to an account on RoleGranted event', () => {
+    test('Should assign UPGRADER_ROLE to an account on RoleGranted event', () => {
         // --- GIVEN
         const event = createRoleGrantedEvent(
             Address.fromString(ACCOUNT_ID),

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -7,7 +7,7 @@ import { createRoleGrantedEvent, createRoleRevokedEvent } from '../utils/utils';
 
 // Constants for testing
 const ACCOUNT_ID = '0x1234567890abcdef1234567890abcdef12345678';
-const UPGRADER_ROLE = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
+const UPGRADER_ROLE_ID = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
 const MANAGER_ROLE_ID = '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08';
 const MINTER_ROLE_ID = '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6';
 const UNKNOWN_ROLE_ID = '0x544b2cd71ba72d14e3ad1fab938f5145ba5fc248560466e1d7cc20c78080e0fb';
@@ -29,11 +29,11 @@ describe('Role Handlers', () => {
         clearStore();
     });
 
-    test('Should assign UPGRADER_ROLE to an account on RoleGranted event', () => {
+    test('Should assign UPGRADER_ROLE_ID to an account on RoleGranted event', () => {
         // --- GIVEN
         const event = createRoleGrantedEvent(
             Address.fromString(ACCOUNT_ID),
-            Bytes.fromHexString(UPGRADER_ROLE),
+            Bytes.fromHexString(UPGRADER_ROLE_ID),
         );
 
         // WHEN
@@ -41,8 +41,8 @@ describe('Role Handlers', () => {
 
         // THEN
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
-        assert.fieldEquals('Account', ACCOUNT_ID, 'role', UPGRADER_ROLE);
-        assert.fieldEquals('Role', UPGRADER_ROLE, 'name', 'UPGRADER_ROLE');
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', UPGRADER_ROLE_ID);
+        assert.fieldEquals('Role', UPGRADER_ROLE_ID, 'name', 'UPGRADER_ROLE');
     });
 
     test('Should assign MANAGER_ROLE to an account on RoleGranted event', () => {
@@ -75,6 +75,24 @@ describe('Role Handlers', () => {
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
         assert.fieldEquals('Account', ACCOUNT_ID, 'role', MINTER_ROLE_ID);
         assert.fieldEquals('Role', MINTER_ROLE_ID, 'name', 'MINTER_ROLE');
+    });
+
+    test('Should revoke UPGRADER_ROLE from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, UPGRADER_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(UPGRADER_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', UPGRADER_ROLE_ID, 'name', 'UPGRADER_ROLE');
     });
 
     test('Should revoke MANAGER_ROLE from an account on RoleRevoked event', () => {

--- a/tests/unit/voucherhub/Role.test.ts
+++ b/tests/unit/voucherhub/Role.test.ts
@@ -8,6 +8,8 @@ import { createRoleGrantedEvent, createRoleRevokedEvent } from '../utils/utils';
 // Constants for testing
 const ACCOUNT_ID = '0x1234567890abcdef1234567890abcdef12345678';
 const VALID_ROLE_ID = '0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3';
+const MANAGER_ROLE_ID = '0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08';
+const MINTER_ROLE_ID = '0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6';
 const UNKNOWN_ROLE_ID = '0x544b2cd71ba72d14e3ad1fab938f5145ba5fc248560466e1d7cc20c78080e0fb';
 
 function setupInitialAccount(accountId: string, roleId: string | null): void {
@@ -27,7 +29,7 @@ describe('Role Handlers', () => {
         clearStore();
     });
 
-    test('Should assign a recognized role to an account on RoleGranted event', () => {
+    test('Should assign UPGRADER_ROLE to an account on RoleGranted event', () => {
         // --- GIVEN
         const event = createRoleGrantedEvent(
             Address.fromString(ACCOUNT_ID),
@@ -41,6 +43,74 @@ describe('Role Handlers', () => {
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
         assert.fieldEquals('Account', ACCOUNT_ID, 'role', VALID_ROLE_ID);
         assert.fieldEquals('Role', VALID_ROLE_ID, 'name', 'UPGRADER_ROLE');
+    });
+
+    test('Should assign MANAGER_ROLE to an account on RoleGranted event', () => {
+        // --- GIVEN
+        const event = createRoleGrantedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(MANAGER_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleGranted(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', MANAGER_ROLE_ID);
+        assert.fieldEquals('Role', MANAGER_ROLE_ID, 'name', 'MANAGER_ROLE');
+    });
+
+    test('Should assign MINTER_ROLE to an account on RoleGranted event', () => {
+        // --- GIVEN
+        const event = createRoleGrantedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(MINTER_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleGranted(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', MINTER_ROLE_ID);
+        assert.fieldEquals('Role', MINTER_ROLE_ID, 'name', 'MINTER_ROLE');
+    });
+
+    test('Should revoke MANAGER_ROLE from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, MANAGER_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(MANAGER_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', MANAGER_ROLE_ID, 'name', 'MANAGER_ROLE');
+    });
+
+    test('Should revoke MINTER_ROLE from an account on RoleRevoked event', () => {
+        // --- GIVEN
+        setupInitialAccount(ACCOUNT_ID, MINTER_ROLE_ID);
+
+        const event = createRoleRevokedEvent(
+            Address.fromString(ACCOUNT_ID),
+            Bytes.fromHexString(MINTER_ROLE_ID),
+        );
+
+        // WHEN
+        handleRoleRevoked(event);
+
+        // THEN
+        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
+        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
+        assert.fieldEquals('Role', MINTER_ROLE_ID, 'name', 'MINTER_ROLE');
     });
 
     test('Should assign an unknown role to an account on RoleGranted event', () => {
@@ -57,24 +127,6 @@ describe('Role Handlers', () => {
         assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
         assert.fieldEquals('Account', ACCOUNT_ID, 'role', UNKNOWN_ROLE_ID);
         assert.fieldEquals('Role', UNKNOWN_ROLE_ID, 'name', 'UNKNOWN_ROLE');
-    });
-
-    test('Should revoke a recognized role from an account on RoleRevoked event', () => {
-        // --- GIVEN
-        setupInitialAccount(ACCOUNT_ID, VALID_ROLE_ID);
-
-        const event = createRoleRevokedEvent(
-            Address.fromString(ACCOUNT_ID),
-            Bytes.fromHexString(VALID_ROLE_ID),
-        );
-
-        // WHEN
-        handleRoleRevoked(event);
-
-        // THEN
-        assert.fieldEquals('Account', ACCOUNT_ID, 'id', ACCOUNT_ID);
-        assert.fieldEquals('Account', ACCOUNT_ID, 'role', 'null');
-        assert.fieldEquals('Role', VALID_ROLE_ID, 'name', 'UPGRADER_ROLE');
     });
 
     test('Should revoke an unknown role from an account on RoleRevoked event', () => {


### PR DESCRIPTION
- [x] Handle RoleGranted Event: Assigns a **recognized** or **unknown** role to an account by creating or updating both Account and Role entities. Recognized roles taking into account by the subgraph are :
- `DEFAULT_ADMIN_ROLE` (`0x00`)
- `UPGRADER_ROLE` (`0x189ab7a9244df0848122154315af71fe140f3db0fe014031783b0946b8c9d2e3`)
- `MANAGER_ROLE` (`0x241ecf16d79d0f8dbfb92cbc07fe17840425976cf0667f022fe9877caa831b08`)
- `MINTER_ROLE` (`0x9f2df0fed2c77648de5860a4cc508cd0818c85b8b8a1ab4ceeef8d981c8956a6`)

- [x] Handle RoleRevoked Event: Removes the role from the account while keeping Role entities intact.

Ensures clean and consistent state management for role-based events.