### PR TITLE
Fixing nRLC to RLC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,5 +29,6 @@
   - AccountAuthorized, AccountUnauthorized (#20)
   - VoucherTypeDurationUpdated, VoucherTypeDescriptionUpdated (#21)
   - VoucherTypeCreated (#22)
+- Set voucher balance, value, app/dataset/wp price as BigDecimal (#23)
 
 ## v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,6 @@
   - AccountAuthorized, AccountUnauthorized (#20)
   - VoucherTypeDurationUpdated, VoucherTypeDescriptionUpdated (#21)
   - VoucherTypeCreated (#22)
-- Set voucher balance, value, app/dataset/wp price as BigDecimal (#23)
+- Set voucher balance, value, app/dataset/workerpool price as BigDecimal (#23)
 
 ## v1.0.0

--- a/schema.graphql
+++ b/schema.graphql
@@ -28,8 +28,8 @@ type Voucher @entity {
   owner: Account!
   expiration: BigInt!
   voucherType: VoucherType!
-  value: BigInt! # last funding value
-  balance: BigInt!
+  value: BigDecimal! # last funding value
+  balance: BigDecimal!
   authorizedAccounts: [Account!]!
   fundings: [VoucherFunding!]! @derivedFrom(field: "voucher")
   deals: [Deal!]! @derivedFrom(field: "sponsor")
@@ -38,21 +38,21 @@ type Voucher @entity {
 interface VoucherFunding {
   id: ID!
   timestamp: BigInt!
-  value: BigInt!
+  value: BigDecimal!
   voucher: Voucher!
 }
 
 type VoucherCreation implements VoucherFunding @entity {
   id: ID!
   timestamp: BigInt!
-  value: BigInt!
+  value: BigDecimal!
   voucher: Voucher!
 }
 
 type VoucherTopUp implements VoucherFunding @entity {
   id: ID!
   timestamp: BigInt!
-  value: BigInt!
+  value: BigDecimal!
   voucher: Voucher!
 }
 
@@ -87,14 +87,14 @@ type Workerpool implements Asset @entity {
 type Deal @entity {
   id: ID!
   sponsor: Voucher # voucher specific
-  sponsoredAmount: BigInt # voucher specific
+  sponsoredAmount: BigDecimal # voucher specific
   timestamp: BigInt!
   requester: Account!
   app: App!
   dataset: Dataset
   workerpool: Workerpool!
   botSize: BigInt!
-  appPrice: BigInt!
-  datasetPrice: BigInt!
-  workerpoolPrice: BigInt!
+  appPrice: BigDecimal!
+  datasetPrice: BigDecimal!
+  workerpoolPrice: BigDecimal!
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import { Account, App, Dataset, Role, Workerpool } from '../generated/schema';
 import { App as AppContract } from '../generated/templates/Voucher/App';
 import { Dataset as DatasetContract } from '../generated/templates/Voucher/Dataset';
@@ -60,9 +60,14 @@ export function getEventId(event: ethereum.Event): string {
     return event.transaction.hash.toHex() + '_' + event.transactionLogIndex.toString();
 }
 
-export function nRLCToRLC(value: BigInt): BigInt {
-    let divisor = BigInt.fromI32(1_000_000_000);
-    return value.div(divisor);
+export function nRLCToRLC(value: BigInt): BigDecimal {
+    let divisor = BigDecimal.fromString('1000000000');
+    return value.divDecimal(divisor);
+}
+
+export function RLCtonRLC(value: BigDecimal): BigInt {
+    let multiplier = BigDecimal.fromString('1000000000');
+    return BigInt.fromString(value.times(multiplier).toString());
 }
 
 export function getRoleName(roleId: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -65,7 +65,7 @@ export function nRLCToRLC(value: BigInt): BigDecimal {
     return value.divDecimal(divisor);
 }
 
-export function RLCtonRLC(value: BigDecimal): BigInt {
+export function toNanoRLC(value: BigDecimal): BigInt {
     let multiplier = BigDecimal.fromString('1000000000');
     return BigInt.fromString(value.times(multiplier).toString());
 }

--- a/tests/unit/utils/utils.ts
+++ b/tests/unit/utils/utils.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts';
 import { newMockEvent } from 'matchstick-as/assembly/index';
 import {
     EligibleAssetAdded,
@@ -15,7 +15,6 @@ import {
     AccountAuthorized,
     AccountUnauthorized,
 } from '../../../generated/templates/Voucher/Voucher';
-import { nRLCToRLC } from '../../../src/utils';
 import { EventParamBuilder } from './EventParamBuilder';
 
 export function createVoucherCreatedEvent(
@@ -280,16 +279,16 @@ export function createAndSaveVoucher(
     address: string,
     typeId: string,
     owner: string,
-    value: BigInt,
-    balance: BigInt,
+    value: BigDecimal,
+    balance: BigDecimal,
     expiration: BigInt,
     authorizedAccounts: string[] = [],
 ): void {
     let voucher = new Voucher(address);
     voucher.voucherType = typeId;
     voucher.owner = owner;
-    voucher.value = nRLCToRLC(value);
-    voucher.balance = nRLCToRLC(balance);
+    voucher.value = value;
+    voucher.balance = balance;
     voucher.expiration = expiration;
     voucher.authorizedAccounts = authorizedAccounts;
     voucher.save();

--- a/tests/unit/utils/utils.ts
+++ b/tests/unit/utils/utils.ts
@@ -15,6 +15,7 @@ import {
     AccountAuthorized,
     AccountUnauthorized,
 } from '../../../generated/templates/Voucher/Voucher';
+import { nRLCToRLC } from '../../../src/utils';
 import { EventParamBuilder } from './EventParamBuilder';
 
 export function createVoucherCreatedEvent(
@@ -287,8 +288,8 @@ export function createAndSaveVoucher(
     let voucher = new Voucher(address);
     voucher.voucherType = typeId;
     voucher.owner = owner;
-    voucher.value = value;
-    voucher.balance = balance;
+    voucher.value = nRLCToRLC(value);
+    voucher.balance = nRLCToRLC(balance);
     voucher.expiration = expiration;
     voucher.authorizedAccounts = authorizedAccounts;
     voucher.save();

--- a/tests/unit/voucher/AccountAuthorized.test.ts
+++ b/tests/unit/voucher/AccountAuthorized.test.ts
@@ -15,8 +15,8 @@ const VOUCHER_DURATION = BigInt.fromI32(86400);
 const VOUCHER_TYPE_ELIGIBLE_ASSETS: string[] = [];
 
 const VOUCHER_OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-const VOUCHER_VALUE = BigDecimal.fromString('100');
-const VOUCHER_BALANCE = BigDecimal.fromString('50');
+const VOUCHER_VALUE = BigDecimal.fromString('100.123');
+const VOUCHER_BALANCE = BigDecimal.fromString('50.456');
 const VOUCHER_EXPIRATION = BigInt.fromI32(999999);
 const VOUCHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 

--- a/tests/unit/voucher/AccountAuthorized.test.ts
+++ b/tests/unit/voucher/AccountAuthorized.test.ts
@@ -1,6 +1,6 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
-import { RLCtonRLC } from '../../../src/utils';
+import { toNanoRLC } from '../../../src/utils';
 import { handleAccountAuthorized } from '../../../src/voucher';
 import {
     createAccountAuthorizedEvent,
@@ -42,8 +42,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            RLCtonRLC(VOUCHER_VALUE),
-            RLCtonRLC(VOUCHER_BALANCE),
+            toNanoRLC(VOUCHER_VALUE),
+            toNanoRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [], // Initialize the array
         );
@@ -98,8 +98,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            RLCtonRLC(VOUCHER_VALUE),
-            RLCtonRLC(VOUCHER_BALANCE),
+            toNanoRLC(VOUCHER_VALUE),
+            toNanoRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount], // Already authorized
         );

--- a/tests/unit/voucher/AccountAuthorized.test.ts
+++ b/tests/unit/voucher/AccountAuthorized.test.ts
@@ -1,5 +1,6 @@
-import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
+import { RLCtonRLC } from '../../../src/utils';
 import { handleAccountAuthorized } from '../../../src/voucher';
 import {
     createAccountAuthorizedEvent,
@@ -14,8 +15,8 @@ const VOUCHER_DURATION = BigInt.fromI32(86400);
 const VOUCHER_TYPE_ELIGIBLE_ASSETS: string[] = [];
 
 const VOUCHER_OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-const VOUCHER_VALUE = BigInt.fromI32(100);
-const VOUCHER_BALANCE = BigInt.fromI32(50);
+const VOUCHER_VALUE = BigDecimal.fromString('100');
+const VOUCHER_BALANCE = BigDecimal.fromString('50');
 const VOUCHER_EXPIRATION = BigInt.fromI32(999999);
 const VOUCHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 
@@ -41,8 +42,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            VOUCHER_VALUE,
-            VOUCHER_BALANCE,
+            RLCtonRLC(VOUCHER_VALUE),
+            RLCtonRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [], // Initialize the array
         );
@@ -97,8 +98,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            VOUCHER_VALUE,
-            VOUCHER_BALANCE,
+            RLCtonRLC(VOUCHER_VALUE),
+            RLCtonRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount], // Already authorized
         );

--- a/tests/unit/voucher/AccountAuthorized.test.ts
+++ b/tests/unit/voucher/AccountAuthorized.test.ts
@@ -1,6 +1,5 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
-import { toNanoRLC } from '../../../src/utils';
 import { handleAccountAuthorized } from '../../../src/voucher';
 import {
     createAccountAuthorizedEvent,
@@ -42,8 +41,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            toNanoRLC(VOUCHER_VALUE),
-            toNanoRLC(VOUCHER_BALANCE),
+            VOUCHER_VALUE,
+            VOUCHER_BALANCE,
             VOUCHER_EXPIRATION,
             [], // Initialize the array
         );
@@ -98,8 +97,8 @@ describe('AccountAuthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            toNanoRLC(VOUCHER_VALUE),
-            toNanoRLC(VOUCHER_BALANCE),
+            VOUCHER_VALUE,
+            VOUCHER_BALANCE,
             VOUCHER_EXPIRATION,
             [authorizedAccount], // Already authorized
         );

--- a/tests/unit/voucher/AccountUnauthorized.test.ts
+++ b/tests/unit/voucher/AccountUnauthorized.test.ts
@@ -15,8 +15,8 @@ const VOUCHER_DURATION = BigInt.fromI32(86400);
 const VOUCHER_TYPE_ELIGIBLE_ASSETS: string[] = [];
 
 const VOUCHER_OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-const VOUCHER_VALUE = BigDecimal.fromString('100');
-const VOUCHER_BALANCE = BigDecimal.fromString('50');
+const VOUCHER_VALUE = BigDecimal.fromString('100.123');
+const VOUCHER_BALANCE = BigDecimal.fromString('50.456');
 const VOUCHER_EXPIRATION = BigInt.fromI32(999999);
 const VOUCHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 

--- a/tests/unit/voucher/AccountUnauthorized.test.ts
+++ b/tests/unit/voucher/AccountUnauthorized.test.ts
@@ -1,6 +1,5 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
-import { toNanoRLC } from '../../../src/utils';
 import { handleAccountUnauthorized } from '../../../src/voucher';
 import {
     createAccountUnauthorizedEvent,
@@ -41,8 +40,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            toNanoRLC(VOUCHER_VALUE),
-            toNanoRLC(VOUCHER_BALANCE),
+            VOUCHER_VALUE,
+            VOUCHER_BALANCE,
             VOUCHER_EXPIRATION,
             [authorizedAccount1, authorizedAccount2],
         );
@@ -96,8 +95,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            toNanoRLC(VOUCHER_VALUE),
-            toNanoRLC(VOUCHER_BALANCE),
+            VOUCHER_VALUE,
+            VOUCHER_BALANCE,
             VOUCHER_EXPIRATION,
             [],
         );
@@ -123,8 +122,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            toNanoRLC(VOUCHER_VALUE),
-            toNanoRLC(VOUCHER_BALANCE),
+            VOUCHER_VALUE,
+            VOUCHER_BALANCE,
             VOUCHER_EXPIRATION,
             [authorizedAccount],
         );

--- a/tests/unit/voucher/AccountUnauthorized.test.ts
+++ b/tests/unit/voucher/AccountUnauthorized.test.ts
@@ -1,6 +1,6 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
-import { RLCtonRLC } from '../../../src/utils';
+import { toNanoRLC } from '../../../src/utils';
 import { handleAccountUnauthorized } from '../../../src/voucher';
 import {
     createAccountUnauthorizedEvent,
@@ -41,8 +41,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            RLCtonRLC(VOUCHER_VALUE),
-            RLCtonRLC(VOUCHER_BALANCE),
+            toNanoRLC(VOUCHER_VALUE),
+            toNanoRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount1, authorizedAccount2],
         );
@@ -96,8 +96,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            RLCtonRLC(VOUCHER_VALUE),
-            RLCtonRLC(VOUCHER_BALANCE),
+            toNanoRLC(VOUCHER_VALUE),
+            toNanoRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [],
         );
@@ -123,8 +123,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            RLCtonRLC(VOUCHER_VALUE),
-            RLCtonRLC(VOUCHER_BALANCE),
+            toNanoRLC(VOUCHER_VALUE),
+            toNanoRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount],
         );

--- a/tests/unit/voucher/AccountUnauthorized.test.ts
+++ b/tests/unit/voucher/AccountUnauthorized.test.ts
@@ -1,5 +1,6 @@
-import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
+import { RLCtonRLC } from '../../../src/utils';
 import { handleAccountUnauthorized } from '../../../src/voucher';
 import {
     createAccountUnauthorizedEvent,
@@ -14,8 +15,8 @@ const VOUCHER_DURATION = BigInt.fromI32(86400);
 const VOUCHER_TYPE_ELIGIBLE_ASSETS: string[] = [];
 
 const VOUCHER_OWNER = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-const VOUCHER_VALUE = BigInt.fromI32(100);
-const VOUCHER_BALANCE = BigInt.fromI32(50);
+const VOUCHER_VALUE = BigDecimal.fromString('100');
+const VOUCHER_BALANCE = BigDecimal.fromString('50');
 const VOUCHER_EXPIRATION = BigInt.fromI32(999999);
 const VOUCHER_ADDRESS = '0x1234567890123456789012345678901234567890';
 
@@ -40,8 +41,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            VOUCHER_VALUE,
-            VOUCHER_BALANCE,
+            RLCtonRLC(VOUCHER_VALUE),
+            RLCtonRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount1, authorizedAccount2],
         );
@@ -95,8 +96,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            VOUCHER_VALUE,
-            VOUCHER_BALANCE,
+            RLCtonRLC(VOUCHER_VALUE),
+            RLCtonRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [],
         );
@@ -122,8 +123,8 @@ describe('AccountUnauthorizedEvent', () => {
             VOUCHER_ADDRESS,
             VOUCHER_TYPE_ID,
             VOUCHER_OWNER,
-            VOUCHER_VALUE,
-            VOUCHER_BALANCE,
+            RLCtonRLC(VOUCHER_VALUE),
+            RLCtonRLC(VOUCHER_BALANCE),
             VOUCHER_EXPIRATION,
             [authorizedAccount],
         );

--- a/tests/unit/voucherhub/VoucherCreated.test.ts
+++ b/tests/unit/voucherhub/VoucherCreated.test.ts
@@ -1,7 +1,7 @@
 import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
 import { App, VoucherType } from '../../../generated/schema';
-import { RLCtonRLC } from '../../../src/utils';
+import { toNanoRLC } from '../../../src/utils';
 import { handleVoucherCreated } from '../../../src/voucherHub';
 import { createVoucherCreatedEvent } from '../utils/utils';
 
@@ -34,7 +34,7 @@ describe('VoucherCreatedEvent', () => {
             Address.fromString(voucherAddress),
             Address.fromString(owner),
             BigInt.fromString(voucherTypeId),
-            RLCtonRLC(rlcValue),
+            toNanoRLC(rlcValue),
             expiration,
         );
 

--- a/tests/unit/voucherhub/VoucherCreated.test.ts
+++ b/tests/unit/voucherhub/VoucherCreated.test.ts
@@ -1,6 +1,7 @@
-import { Address, BigInt } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt } from '@graphprotocol/graph-ts';
 import { assert, beforeEach, clearStore, describe, test } from 'matchstick-as/assembly/index';
 import { App, VoucherType } from '../../../generated/schema';
+import { RLCtonRLC } from '../../../src/utils';
 import { handleVoucherCreated } from '../../../src/voucherHub';
 import { createVoucherCreatedEvent } from '../utils/utils';
 
@@ -26,15 +27,14 @@ describe('VoucherCreatedEvent', () => {
 
         let voucherAddress = '0x1234567890123456789012345678901234567890';
         let owner = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
-        let rlcValue = BigInt.fromI32(2); // in RLC
-        let nRlcValue = rlcValue.times(BigInt.fromI32(1_000_000_000)); // in nRLC
+        let rlcValue = BigDecimal.fromString('2'); // in RLC
         let expiration = BigInt.fromI32(1234567890);
 
         let event = createVoucherCreatedEvent(
             Address.fromString(voucherAddress),
             Address.fromString(owner),
             BigInt.fromString(voucherTypeId),
-            nRlcValue,
+            RLCtonRLC(rlcValue),
             expiration,
         );
 


### PR DESCRIPTION
The previous implementation #11 the voucher value, balance, value, app/dataset/wp price  could not be floats 
- Consider voucher value and balance as RLC not in nRLC anymore 
- set voucher balance, value, app/dataset/wp price as BigDecimal
- create RLC => nRLC utils fonction for tests 